### PR TITLE
Revert "selinux: workaround for moto blobs"

### DIFF
--- a/security/selinux/hooks.c
+++ b/security/selinux/hooks.c
@@ -3235,16 +3235,7 @@ static int selinux_file_mprotect(struct vm_area_struct *vma,
 			 * modified content.  This typically should only
 			 * occur for text relocations.
 			 */
-			 /* STARGO: Hack for Moto blobs */
-			if (strcmp(current->comm, "mm-qcamera-daem") &&
-			    strcmp(current->comm, "mpdecision") &&
-			    strcmp(current->comm, "qdumpd") &&
-			    strcmp(current->comm, "qmuxd") &&
-			    strcmp(current->comm, "rmt_storage") &&
-			    strcmp(current->comm, "sensors.qcom") &&
-			    strcmp(current->comm, "thermald") &&
-			    strcmp(current->comm, "whisperd"))
-				rc = file_has_perm(cred, vma->vm_file, FILE__EXECMOD);
+			rc = file_has_perm(cred, vma->vm_file, FILE__EXECMOD);
 		}
 		if (rc)
 			return rc;


### PR DESCRIPTION
Nick Kralevich provided a way better solution to fix this. Thanks :-)

This reverts commit c656ca1d4502a9c6072205b09b0694f71d978306.

Change-Id: I7301d24af7207731836b593254718ab4eb944c3f
